### PR TITLE
Fix landing page examples section grid overflow, improve font size

### DIFF
--- a/resources/public/css/main.css
+++ b/resources/public/css/main.css
@@ -318,6 +318,14 @@ figcaption
   -webkit-transform: rotate(45deg);
 }
 
+.fluid-text-size-container {
+  container-type: inline-size;
+}
+
+.fluid-text-size-container pre {
+  font-size: clamp(0.5rem, 2.5cqi, 2rem) !important;
+}
+
 /* Custom font */
 @import url(https://cdn.jsdelivr.net/npm/firacode@6.2.0/distr/fira_code.css);
 @supports (font-variation-settings: normal) {

--- a/src/org/jank_lang/page/landing/view.clj
+++ b/src/org/jank_lang/page/landing/view.clj
@@ -209,7 +209,7 @@
                                  and `merge-with` help create an index from genre to
                                  movie id with ease. No lenses are required for
                                  working with nested data.")]]
-       [:div {:class "column is-8"}
+       [:div {:class "column is-6 fluid-text-size-container"}
         (html->hiccup {} (util/slurp-html! "landing/example/movies.html"))]]
 
       [:div {:class "columns is-vcentered"}
@@ -221,7 +221,7 @@
                                  a powerful `loop` macro for more imperative-style
                                  loops while still being purely functional. Each `loop` has one or more
                                  corresponding `recur` usages which must be in tail position.")]]
-       [:div {:class "column is-8"}
+       [:div {:class "column is-6 fluid-text-size-container"}
         (html->hiccup {} (util/slurp-html! "landing/example/size-human-readable.html"))]]
 
       [:div {:class "columns is-vcentered"}
@@ -232,7 +232,7 @@
          (util/markdown->hiccup "jank's strings, as well as most of its other data structures, are
                                  immutable. However, jank provides such powerful tools for working
                                  with data that mutability is very rarely a concern.")]]
-       [:div {:class "column is-8"}
+       [:div {:class "column is-6 fluid-text-size-container"}
         (html->hiccup {} (util/slurp-html! "landing/example/truncate-string.html"))]]
 
       [:div {:class "columns is-vcentered"}
@@ -245,5 +245,5 @@
                                  contain different values. `with-redefs` redefines a var within its
                                  body's scope, which is very useful for removing side effects from
                                  test cases or forcing functions to return specific values.")]]
-       [:div {:class "column is-8"}
+       [:div {:class "column is-6 fluid-text-size-container"}
         (html->hiccup {} (util/slurp-html! "landing/example/with-redefs.html"))]]]]]))


### PR DESCRIPTION
### Before
<img width="2928" height="1910" alt="CleanShot 2025-11-19 at 19 50 05@2x" src="https://github.com/user-attachments/assets/0d794acc-6662-4f33-a959-77816b048d27" />

### After
<img width="2928" height="1910" alt="CleanShot 2025-11-19 at 19 48 40@2x" src="https://github.com/user-attachments/assets/4665dcd0-88f2-4daa-8196-082bc9dfaee0" />
